### PR TITLE
Agrego mi aporte sobre llaves ssh para Github

### DIFF
--- a/CAPITULOS/mel-git-claves-ssh.md
+++ b/CAPITULOS/mel-git-claves-ssh.md
@@ -1,0 +1,111 @@
+# 🔑 Git y las llaves mágicas (SSH)
+
+## 📌 Problema
+Cuando quieres clonar un repositorio desde GitHub, lo primero que muchos hacemos es ir al famoso **botón verde “Code”** y copiar el enlace que aparece arriba. Ese enlace es **HTTPS**.
+ 
+Con HTTPS, cada vez que hagas `git push` o `git pull`, GitHub te va a pedir el token.  
+O sea, es como si cada vez que quisieras entrar a tu casa tuvieras que ir hasta la inmobiliaria a pedir la llave.😩  
+
+Acá entra la magia de **SSH** ✨  
+Cuando configurás las claves, tu compu y GitHub se reconocen como amigos de confianza.  
+Entonces podés clonar el repo con el link **SSH** (también está en ese mismo botón verde, al lado 👀) y te olvidás de poner el token cada dos por tres.  
+
+En resumen:  
+- **HTTPS** → pedís la llave prestada cada vez.  
+- **SSH** → ya tenés tu copia propia y entrás directo. 🚀
+
+
+---
+
+## ⚡ Paso a paso
+
+### 1. Generar tu par de claves
+En la terminal, corré:
+```bash
+ssh-keygen -t ed25519 -C "tu-email@ejemplo.com"
+````
+
+Esto va a crear **dos archivos** en `~/.ssh/`:
+
+* `id_ed25519` → clave **privada** (NO se comparte 🚫).
+* `id_ed25519.pub` → clave **pública** (esta sí la compartís con GitHub).
+
+---
+
+### 2. Agregar la clave privada al agente SSH
+
+Le decimos al sistema que guarde y recuerde la clave:
+
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+---
+
+### 3. Copiar la clave pública
+
+Mostrala con:
+
+```bash
+cat ~/.ssh/id_ed25519.pub
+```
+
+Copia todo el texto que se muestre en la terminal.
+
+---
+
+### 4. Subir la clave a GitHub
+
+* Entrá a **Settings > SSH and GPG keys** en tu perfil de GitHub.
+* Click en **New SSH key** → pegá el contenido de la clave pública.
+
+---
+
+### 5. Probar conexión
+
+```bash
+ssh -T git@github.com
+```
+
+Si te dice algo como:
+`Hi <tu-usuario>! You've successfully authenticated...`
+🎉 ¡Listo! GitHub ya no te pedirá token.
+
+---
+
+## 🪄 Analogía mágica
+
+Pensalo así:
+
+* La **clave pública** es como darle una copia de tu llave al portero del edificio.
+* La **clave privada** es tu llave personal: solo vos la tenés, no la prestás nunca.
+* Cuando querés entrar (hacer push/pull), el portero (GitHub) te reconoce y abre sin pedirte nada más.
+
+En vez de tocar timbre con el token cada vez que llegás, tu llave SSH te deja pasar directo. 🚀
+
+---
+
+## 📌 Tip final
+
+Si trabajás en varias máquinas (ej: tu compu personal y la del trabajo), podés generar un par de claves para cada una y subirlas todas a GitHub.
+Así no hay peleas de acceso ni dramas de permisos. 😉
+
+---
+
+## ⚠️ Errores comunes
+
+* Olvidarte de **agregar la clave al agente SSH** → Git te va a mirar como diciendo: *“¿y vos quién sos?”*.
+* Subir la **clave privada** en lugar de la pública → eso es como darle tu llave real a un extraño… ¡NO lo hagas jamás! 🚫🔓
+
+---
+## 📚 Documentación oficial
+
+- [Generar una nueva clave SSH y agregarla al agente (GitHub Docs)](https://docs.github.com/es/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+
+## 🎥 Videos de apoyo
+
+- [Configurar Llave SSH para GitHub: Tutorial Paso a Paso(Windows)](https://www.youtube.com/watch?v=Y9jXwyDbTmQ)
+
+- [Clonar Repositorio de github con ssh en Ubuntu-Debian](https://www.youtube.com/watch?v=1ZjnowjLHug)
+

--- a/INDICE.md
+++ b/INDICE.md
@@ -5,3 +5,4 @@ No importa si es útil, absurdo o gracioso: lo importante es que figure en el í
 
 10/09 - begin (cree el archivo para poder añadir la carpeta de capitulos XDD)
 10/09 - federico_anecdota-k8s (lo subo porque siempre me hace reir, la proxima contribucion sera algo mas serio (o no))
+11/09 - mel-git-clave-ssh (para decirle basta! a los tokens de GitHub por HTTPS)


### PR DESCRIPTION
Agregué el capítulo, mel-git-claves-ssh.md` en la carpeta `CAPITULOS/`, también lo agregué al índice.
Donde explico cómo generar claves públicas y privadas para conectarse a GitHub por SSH.